### PR TITLE
Use run instead of command in main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,11 +23,9 @@ jobs:
 
       # Runs RubyCritic App
       - name: RubyCritic App
-        run: 
-          command: mkdir -p tmp/rubycritic && bundle exec rubycritic --no-browser -p tmp/rubycritic/rubycritic-app -s 80 app config lib
+        run: mkdir -p tmp/rubycritic && bundle exec rubycritic --no-browser -p tmp/rubycritic/rubycritic-app -s 80 app config lib
 
       # Runs RubyCritic on Tests
       - name: RubyCritic on Tests
-        run: 
-          command: mkdir -p tmp/rubycritic && bundle exec rubycritic --no-browser -p tmp/rubycritic/rubycritic-app -s 65 spec test
+        run: mkdir -p tmp/rubycritic && bundle exec rubycritic --no-browser -p tmp/rubycritic/rubycritic-app -s 65 spec test
 


### PR DESCRIPTION
# Description
What did you implemented/Why did you implemented this:
Update `main.yml` to use `run` instead of `command` since the later seems not to be valid