### PR TITLE
Rakefile NamError Rubocop uninitialized

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,7 @@
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
 require_relative 'config/application'
+require 'rubocop/rake_task'
 
 Rails.application.load_tasks
 


### PR DESCRIPTION
Co-authored-by: alx1313 <alx2406@hotmail.com>

# Description
In automatic deployment setup, Heroku throws an error, build log shows the message "Push rejected, failed to compile Ruby app." and the error caused by NameError: uninitialized constant RuboCop, so rubocop/rake_task was added to use the constant RuboCop.

  ## Screenshots 
Build log on Heroku
![InkedScreenshot_2020-10-09 control-almacen-bc · Build Heroku_LI](https://user-images.githubusercontent.com/44456304/95624008-ccc8ec00-0a3b-11eb-96c7-c32cd2f2cf09.jpg)

Database creation error on local environment
![WhatsApp Image 2020-10-09 at 2 18 36 PM](https://user-images.githubusercontent.com/44456304/95624121-f7b34000-0a3b-11eb-8463-25b6e5ae2f12.jpeg)


