### PR TITLE
Bugfix/7 heroku deployment

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+release: bundle exec rake db:migrate

--- a/README.md
+++ b/README.md
@@ -116,3 +116,6 @@ Para poder instalar el proyecto en su ambiente local, después de clonar el repo
 $ bundle install
 $ yarn --check-files
 ```
+# URL Heroku
+
+[Here](https://control-almacen-bc.herokuapp.com)

--- a/Rakefile
+++ b/Rakefile
@@ -2,10 +2,12 @@
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
 require_relative 'config/application'
-require 'rubocop/rake_task'
 
 Rails.application.load_tasks
 
-RuboCop::RakeTask.new do |task|
-  task.requires << 'rubocop-rails'
+if Rails.env == 'development'
+  require 'rubocop/rake_task'
+  RuboCop::RakeTask.new do |task|
+    task.requires << 'rubocop-rails'
+  end
 end


### PR DESCRIPTION
# Description
Solved Rubocop Rakefile error
- Rubocob failed because it had a conflict with the enviroment, trying to work on production.
- Added a config. on Rakefile to avoid the use of rubocop when the enviroment was on production.

Added an automatic db migration
- Heroku shows error with the tables, migrations were needed on each deployment.
-Added a Procfile to automatize the migrations, solving this error.

 # Testing
This was tested on the manual deployment in Heroku system.
![Screenshot_2020-10-14 control-almacen-bc · GitHub Heroku](https://user-images.githubusercontent.com/51497719/96055874-d347d100-0e4a-11eb-86cd-f6366bd330c4.png)

Co-authored-by: CarlosSe <carlos.seggch@gmail.com>